### PR TITLE
Add support for CryptoPP versions before 6.0

### DIFF
--- a/null_hash.h
+++ b/null_hash.h
@@ -1,5 +1,16 @@
 #include <cryptopp/cryptlib.h>
 
+#if (CRYPTOPP_VERSION <= 600)
+    // cryptopp made the unfathomable decision to add
+    // their byte type to the standard namespace, which
+    // is only fixed later on (from version 6.0)
+    namespace CryptoPP {
+        // use the byte that was erroneously defined
+        // in the global namespace
+        using byte = ::byte;
+    }
+#endif
+
 
 namespace pgp {
 


### PR DESCRIPTION
CryptoPP used to define a 'byte' type in the global namespace. This was fixed in version 6.0. The packet library assumes the 'byte' to be defined in the CryptoPP namespace, which doesn't hold true for older releases.

We now check the CryptoPP version and alias the type where necessary.