### PR TITLE
Use imported targets for Boost

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.5.2)
 
 project(pgp-packet-library
     VERSION     0.1.1
@@ -65,7 +65,7 @@ if(NOT HAVE_STD_SPAN)
     target_compile_definitions(pgp-packet PUBLIC USE_GSL_SPAN)
 endif()
 
-target_include_directories(pgp-packet PUBLIC ${Boost_INCLUDE_DIRS})
+target_link_libraries(pgp-packet Boost::boost)
 
 target_include_directories(pgp-packet PUBLIC ${SODIUM_INCLUDE_DIRS})
 target_link_libraries(pgp-packet ${SODIUM_LIBRARIES})


### PR DESCRIPTION
This uses an imported target (`Boost::boost`) instead of the variables that were used before. Since this requires cmake 3.5.2, the minimum version is raised to 3.5.2.