### PR TITLE
variant/span feature detection using compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,9 @@
-cmake_minimum_required(VERSION 3.5.2)
+cmake_minimum_required(VERSION 3.8.0)
 
 project(pgp-packet-library
     VERSION     0.1.1
     LANGUAGES   CXX
 )
-
-include(CheckIncludeFileCXX)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
 
@@ -50,17 +48,25 @@ set(pgp-packet-sources
     source/signature_subpacket/embedded.cpp
 )
 
-CHECK_INCLUDE_FILE_CXX(variant HAVE_STD_VARIANT)
-CHECK_INCLUDE_FILE_CXX(span HAVE_STD_SPAN)
+include(CheckCXX17SourceRuns)
+
+check_cxx17_source_runs(
+    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/tests/std_variant_test.cpp
+    HAVE_STD_VARIANT)
+check_cxx17_source_runs(
+    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/tests/std_span_test.cpp
+    HAVE_STD_SPAN)
 
 add_library(pgp-packet ${pgp-packet-sources})
 
 if(NOT HAVE_STD_VARIANT)
+    message("No working std::variant found, using mpark::variant")
     set(NEED_MPARK 1)
     target_compile_definitions(pgp-packet PUBLIC USE_MPARK_VARIANT)
 endif()
 
 if(NOT HAVE_STD_SPAN)
+    message("No working std::span found, using gsl::span")
     set(NEED_GSL 1)
     target_compile_definitions(pgp-packet PUBLIC USE_GSL_SPAN)
 endif()
@@ -92,11 +98,7 @@ if(NEED_MPARK)
 endif()
 
 set_property(TARGET pgp-packet PROPERTY CXX_STANDARD 17)
-if(NOT ${CMAKE_VERSION} VERSION_LESS "3.8.0")
-    target_compile_features(pgp-packet PUBLIC cxx_std_17)
-else()
-    message(WARNING "Cannot export requirement for C++17 to users of the pgp-packet library (CMake version < 3.8.0); please set the C++ standard yourself")
-endif()
+target_compile_features(pgp-packet PUBLIC cxx_std_17)
 
 # TODO: Figure out correct flags for other compilers
 if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")

--- a/cmake/Modules/CheckCXX17SourceRuns.cmake
+++ b/cmake/Modules/CheckCXX17SourceRuns.cmake
@@ -1,0 +1,27 @@
+# Implementation idea stolen from CheckCXXSourceRuns, which doesn't support
+# setting the C++ language version
+macro(check_cxx17_source_runs FILENAME VAR)
+    if(NOT CMAKE_REQUIRED_QUIET)
+        message(STATUS "Performing test ${VAR}")
+    endif()
+
+    try_run(${VAR}_EXITCODE ${VAR}_COMPILED
+            ${CMAKE_BINARY_DIR}
+            ${FILENAME}
+            CXX_STANDARD 17)
+
+    if(NOT ${VAR}_COMPILED)
+        set(${VAR}_EXITCODE 1)
+    endif()
+    if(${VAR}_EXITCODE EQUAL 0)
+        set(${VAR} 1 CACHE INTERNAL "Test ${VAR}")
+        if(NOT CMAKE_REQUIRED_QUIET)
+            message(STATUS "Performing test ${VAR} - Success")
+        endif()
+    else()
+        set(${VAR} "" CACHE INTERNAL "Test ${VAR}")
+        if(NOT CMAKE_REQUIRED_QUIET)
+            message(STATUS "Performing test ${VAR} - Failed")
+        endif()
+    endif()
+endmacro()

--- a/cmake/tests/std_span_test.cpp
+++ b/cmake/tests/std_span_test.cpp
@@ -1,0 +1,7 @@
+#include <array>
+#include <span>
+
+int main() {
+    std::span<const char> s1{"test"};
+    std::span<const int> s2{std::array<int, 3>{42, 43, 44}};
+}

--- a/cmake/tests/std_variant_test.cpp
+++ b/cmake/tests/std_variant_test.cpp
@@ -1,0 +1,25 @@
+#include <iostream>
+#include <variant>
+#include <cstdlib>
+
+void okassert(bool ok, const char *description) {
+    if (!ok) {
+        std::cerr << "FAIL: " << description << std::endl;
+        exit(1);
+    }
+}
+
+int main() {
+    std::variant<int, char> v{std::in_place_type_t<char>(), 'a'};
+
+    okassert(std::get<char>(v) == 'a', "std::get not working");
+
+    bool error_thrown = false;
+    try { std::get<int>(v); }
+    catch (std::bad_variant_access &) { error_thrown = true; }
+    okassert(error_thrown, "std::get should throw error");
+
+    std::visit([](auto &&value) {
+        okassert(value == 'a', "std::visit not working");
+    }, v);
+}


### PR DESCRIPTION
This tries to compile some test .cpp files in order to determine whether
&lt;variant> and &lt;span> are not only present, but also usable. Testing this
is necessary for macOS &lt;=10.13, since that provides a &lt;variant> header
that mostly works, but doesn't provide std::visit.