### PR TITLE
Clarify in readme that GCC >= 8.0 is supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The library is centered around the pgp::packet class. This class can be construc
 
 The library has been tested to work with the following C++ compilers:
 
-- g++ 8.3.0 ([fails with 7.4.0](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=91058))
+- g++ >= 8.0 ([fails with versions &lt; 8.0](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=91058))
 - clang++ 8.0.0, 7.1.0, 7.0.1, 6.0, Apple clang 10.0.0
 
 To build the library, the following dependencies need to be installed first:


### PR DESCRIPTION
This is a successor to #24, induced by the response on the linked bug report by Jonathan Wakely.