### PR TITLE
 Build and unit test in Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM debian:buster
+
+RUN apt-get update \
+&&  apt-get -y install \
+        gnupg \
+        software-properties-common \
+        wget \
+&&  wget --quiet -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
+&&  add-apt-repository -y "deb http://apt.llvm.org/buster/ llvm-toolchain-buster-8 main" \
+&&  apt-get update \
+&&  apt-get -y upgrade \
+&&  apt-get -y install \
+        build-essential \
+        clang-8 \
+        clang-tools-8 \
+        cmake \
+        g++-8 \
+        libboost1.67-all-dev \
+        libcrypto++-dev \
+        libsodium-dev \
+&&  apt-get -y autoremove \
+&&  apt-get -y autoclean \
+&&  ln -s $(which llvm-profdata-8) /usr/bin/llvm-profdata \
+&&  ln -s $(which llvm-cov-8) /usr/bin/llvm-cov \
+&&  mkdir /pgp-packet-library
+
+WORKDIR /pgp-packet-library
+
+COPY . /pgp-packet-library
+

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 - [Introduction](#introduction)
 - [Building the library](#building-the-library)
+  - [Building the library in a Docker container](#building-the-library-in-a-docker-container)
 - [Using the library](#using-the-library)
   - [Creating a simple packet](#creating-a-simple-packet)
   - [Encoding and decoding of packet data](#encoding-and-decoding-of-packet-data)
@@ -22,6 +23,7 @@ The library has been tested to work with the following C++ compilers:
 - clang++ 8.0.0, 7.1.0, 7.0.1, 6.0, Apple clang 10.0.0
 
 To build the library, the following dependencies need to be installed first:
+
 - [Boost C++ libraries](https://www.boost.org/)
 - [Libsodium](https://download.libsodium.org/doc/)
 - [Crypto++ Library](https://cryptopp.com/)
@@ -44,6 +46,38 @@ If you wish to install the library (so that it can be automatically found by pro
 `make -C build install`
 
 This command might need administrative privileges. Depending on your operating system and configuration, you might need to use `sudo` or change to an administrator account before executing the command.
+
+### Building the library in a Docker container
+
+The repository contains a `Dockerfile`, which can be used to create a Docker container to build the library and run its unit tests. The generated image is based on _Debian Buster_ and contains all the necessary dependencies to build the library. It also provides different compilers (`clang++-8` and `g++-8` currently) to use.
+
+To build the Docker image, execute the following command from the root of the repository:
+
+```bash
+./build-container.sh
+```
+
+**NOTES:**
+
+- If changes are made to the source code or to the unit tests, the Docker image will have to be rebuilt, because it copies the contents of the repository into the image.
+- The submodules of the repository should already be available before building the image (i.e. `git submodule update --init`).
+
+To build the library and run the unit tests, execute the following command from the root of the repository (after the image has been built):
+
+```bash
+./compiler-and-test-in-docker.sh
+```
+
+By default, the above commands will use `summitto/pgp-packet-library-builder` as the name of the Docker image, and will use the Clang 8 compiler. These settings can be controlled via environment variables:
+
+- The **`PGPPL_BUILDER_IMAGE_NAME`** environment variable can be set to specify the name of the generated docker image.
+- The **`CXX`** environment variable can be set to specify the C++ compiler to be used.
+
+For example, to build the library using `g++-8`, execute the following command:
+
+```bash
+CXX=g++-8 ./compile-and-test-in-docker.sh
+```
 
 ## Using the library
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ To build the Docker image, execute the following command from the root of the re
 To build the library and run the unit tests, execute the following command from the root of the repository (after the image has been built):
 
 ```bash
-./compiler-and-test-in-docker.sh
+./compile-and-test-in-docker.sh
 ```
 
 By default, the above commands will use `summitto/pgp-packet-library-builder` as the name of the Docker image, and will use the Clang 8 compiler. These settings can be controlled via environment variables:

--- a/build-container.sh
+++ b/build-container.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+if [[ -z ${PGPPL_BUILDER_IMAGE_NAME} ]]; then
+    PGPPL_BUILDER_IMAGE_NAME='summitto/pgp-packet-library-builder'
+fi
+
+docker build -t ${PGPPL_BUILDER_IMAGE_NAME} .
+

--- a/compile-and-test-in-docker.sh
+++ b/compile-and-test-in-docker.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+if [[ -z ${PGPPL_BUILDER_IMAGE_NAME} ]]; then
+    PGPPL_BUILDER_IMAGE_NAME='summitto/pgp-packet-library-builder'
+fi
+
+if [[ -z ${CXX} ]]; then
+    CXX="clang++-8"
+fi
+
+compiler_setup="export CXX=${CXX}"
+build_dir="build"
+build_dir_setup="rm -rf ${build_dir} && mkdir ${build_dir} && cd ${build_dir}"
+build_cmd="cmake .. && make -j2"
+test_cmd="./tests/tests"
+
+docker run \
+    --cap-add SYS_PTRACE \
+    ${PGPPL_BUILDER_IMAGE_NAME} \
+    /bin/sh \
+    -c "${compiler_setup} && ${build_dir_setup} && ${build_cmd} && ${test_cmd}"
+


### PR DESCRIPTION
-   Add a `Dockerfile` that installs all the necessary dependencies on
    top of a _Debian Buster_ image and copies the contents of the
    repository into the image.
-   Add `build-container.sh` to conveniently build the Docker image.
-   Add `compile-and-test-in-docker.sh` to build the library and run its
    unit tests inside the Docker image.
-   Add instructions to `README.md` on how to use the Docker image.

By making a contribution to this project, I certify that:

        (a) The contribution was created in whole or in part by me and I
            have the right to submit it under the GPL-3.0 license; or

        (b) The contribution is based upon previous work that, to the best
            of my knowledge, is covered under an appropriate open source
            license and I have the right under that license to submit that
            work with modifications, whether created in whole or in part
            by me, under GPL-3.0 license; or

        (c) The contribution was provided directly to me by some other
            person who certified (a), (b) or (c) and I have not modified
            it.

        (d) I understand and agree that this project and the contribution
            are public and that a record of the contribution (including all
            personal information I submit with it, including my sign-off) is
            maintained indefinitely and may be redistributed consistent with
            this project or the license(s) involved.
