### PR TITLE
Fix for initial zero byte in key in eddsa signature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build
 .*.swp
+default.profraw

--- a/source/eddsa_signature_encoder.cpp
+++ b/source/eddsa_signature_encoder.cpp
@@ -13,11 +13,8 @@ namespace pgp {
     eddsa_signature_encoder::finalize() noexcept
     {
         // the buffer for the signed message and the concatenated key
-        std::array<uint8_t, crypto_sign_BYTES>  signed_message;
-        std::array<uint8_t, 64>                 key_data;
-
-        // ensure that unfilled bytes of key_data are empty
-        std::fill(key_data.begin(), key_data.end(), 0);
+        std::array<uint8_t, crypto_sign_BYTES>  signed_message  { 0 };
+        std::array<uint8_t, 64>                 key_data        { 0 };
 
         // retrieve the key data - ignore the silly leading byte from the public key
         auto public_data = eddsa_key.Q().data().subspan<1>();

--- a/source/eddsa_signature_encoder.cpp
+++ b/source/eddsa_signature_encoder.cpp
@@ -16,13 +16,18 @@ namespace pgp {
         std::array<uint8_t, crypto_sign_BYTES>  signed_message;
         std::array<uint8_t, 64>                 key_data;
 
+        // ensure that unfilled bytes of key_data are empty
+        std::fill(key_data.begin(), key_data.end(), 0);
+
         // retrieve the key data - ignore the silly leading byte from the public key
         auto public_data = eddsa_key.Q().data().subspan<1>();
         auto secret_data = eddsa_key.k().data();
 
         // copy the public key and then the private key
-        auto iter = std::copy(secret_data.begin(), secret_data.end(), key_data.begin());
-        std::copy(public_data.begin(), public_data.end(), iter);
+        assert(public_data.size() <= 32);
+        assert(secret_data.size() <= 32);
+        auto iter = std::copy(secret_data.begin(), secret_data.end(), key_data.begin() + 32 - secret_data.size());
+        std::copy(public_data.begin(), public_data.end(), iter + 32 - public_data.size());
 
         // get the digest to sign
         auto digest_data = digest();


### PR DESCRIPTION
This fixes a problem in the key generation application.

The particular problem happens when in `parameters_eddsa.cpp` of the key generation application, `main_key_derivation` (and thus `main_key_secret`) starts with a zero byte. The derivation strings for the three subkeys can start with a zero byte without any problems. Reproducing the issue is easy: replace (a copy of) `main_key_derivation` with a zero byte in `parameters_eddsa.cpp` of the key generation application, generate an eddsa key, and observe that `gpg --import` finds all signatures invalid.

As for the fix: this basically pads `secret_data` and `public_data` with zeros on the left side. Padding only `secret_data` already fixes the issue, but I gathered that padding `public_data` as well wouldn't hurt. This is for review, though: in the packet library tests, `public_data.size()` is sometimes `< 32`, but that doesn't seem to happen when generating keys with the key generation application. This probably makes sense somehow (maybe because of the 0x40 tag byte?), but I don't see it right now.

This seems to fix the problem for eddsa, but it may very well be that the same problem occurs for ecdsa. I have not looked at that yet.

---

    By making a contribution to this project, I certify that:

        (a) The contribution was created in whole or in part by me and I
            have the right to submit it under the GPL-3.0 license; or

        (b) The contribution is based upon previous work that, to the best
            of my knowledge, is covered under an appropriate open source
            license and I have the right under that license to submit that
            work with modifications, whether created in whole or in part
            by me, under GPL-3.0 license; or

        (c) The contribution was provided directly to me by some other
            person who certified (a), (b) or (c) and I have not modified
            it.

        (d) I understand and agree that this project and the contribution
            are public and that a record of the contribution (including all
            personal information I submit with it, including my sign-off) is
            maintained indefinitely and may be redistributed consistent with
            this project or the license(s) involved.
