### PR TITLE
Move defaulted move constructor and move assignment to header

### DIFF
--- a/include/signature_subpacket/embedded.h
+++ b/include/signature_subpacket/embedded.h
@@ -43,7 +43,7 @@ namespace pgp::signature_subpacket {
              *  Copy and move constructors
              */
             embedded(const embedded &other);
-            embedded(embedded &&other);
+            embedded(embedded &&other) = default;
 
             /**
              *  Destructor
@@ -54,7 +54,7 @@ namespace pgp::signature_subpacket {
              *  Assignment operators
              */
             embedded<subpacket_type, contained_t> &operator=(const embedded &other);
-            embedded<subpacket_type, contained_t> &operator=(embedded &&other);
+            embedded<subpacket_type, contained_t> &operator=(embedded &&other) = default;
 
             /**
              *  Comparison operators

--- a/source/signature_subpacket/embedded.cpp
+++ b/source/signature_subpacket/embedded.cpp
@@ -23,12 +23,6 @@ namespace pgp::signature_subpacket {
     {}
 
     /**
-     *  Move constructor
-     */
-    template <signature_subpacket_type subpacket_type, typename contained_t>
-    embedded<subpacket_type, contained_t>::embedded(embedded &&other) = default;
-
-    /**
      *  Destructor
      */
     template <signature_subpacket_type subpacket_type, typename contained_t>
@@ -47,13 +41,6 @@ namespace pgp::signature_subpacket {
         // allow chaining
         return *this;
     }
-
-    /**
-     *  Move assignment operator
-     */
-    template <signature_subpacket_type subpacket_type, typename contained_t>
-    embedded<subpacket_type, contained_t> &
-    embedded<subpacket_type, contained_t>::operator=(embedded &&other) = default;
 
     /**
      *  Comparison operators


### PR DESCRIPTION
* GCC (8) complained about an unused parameter
* It does not complain when defaulted in the header
* Defaulted functions can be easily inlined by the compiler

By making a contribution to this project, I certify that:

        (a) The contribution was created in whole or in part by me and I
            have the right to submit it under the GPL-3.0 license; or

        (b) The contribution is based upon previous work that, to the best
            of my knowledge, is covered under an appropriate open source
            license and I have the right under that license to submit that
            work with modifications, whether created in whole or in part
            by me, under GPL-3.0 license; or

        (c) The contribution was provided directly to me by some other
            person who certified (a), (b) or (c) and I have not modified
            it.

        (d) I understand and agree that this project and the contribution
            are public and that a record of the contribution (including all
            personal information I submit with it, including my sign-off) is
            maintained indefinitely and may be redistributed consistent with
            this project or the license(s) involved.
