### PR TITLE
Static analysis

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,5 +171,14 @@ if (iwyu_tool_path AND PYTHONINTERP_FOUND)
         COMMAND "${PYTHON_EXECUTABLE}" "${iwyu_tool_path}" -p "${CMAKE_BINARY_DIR}" --
         COMMENT "Running include-what-you-use tool"
         VERBATIM
-)
+    )
+endif()
+
+find_program(clang_tidy_path NAMES clang-tidy)
+if (clang_tidy_path)
+    add_custom_target(tidy
+        COMMAND ${clang_tidy_path} -p="${CMAKE_CURRENT_BINARY_DIR}" ${pgp-packet-sources}
+        COMMENT "Running clang-tidy"
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    )
 endif()

--- a/clang_analyze.sh
+++ b/clang_analyze.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ $# -ge 1 && ($1 = "-h" || $1 = "--help") ]]; then
+    echo >&2 "Usage: $0 [custom CMake arguments...]"
+    echo >&2 "Will compile the library, including tests, using the Clang static analyzer."
+    echo >&2 "Any arguments to the script will be passed verbatim to CMake in addition to"
+    echo >&2 "the arguments necessary for this script."
+    exit 0
+fi
+
+sourcedir="$(dirname "$0")"
+builddir="$(mktemp -d)"
+
+trap "rm -rf '$builddir'" EXIT
+
+nthreads="$(nproc || echo -n "")"
+if [[ -z $nthreads ]]; then
+    nthreads=4
+    echo >&2 "Warning: Could not determine number of CPU cores, using $nthreads"
+fi
+
+CC=clang CXX=clang++ scan-build --use-cc=clang --use-c++=clang++ cmake -S "$sourcedir" -B "$builddir" -DCMAKE_BUILD_TYPE=Debug "$@"
+scan-build --use-cc=clang --use-c++=clang++ make -j$(nproc) -C"$builddir"

--- a/include/util/narrow_cast.h
+++ b/include/util/narrow_cast.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <utility>
+
 
 namespace util {
 

--- a/include/util/transaction.h
+++ b/include/util/transaction.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <utility>
+
 
 namespace util {
 

--- a/include/util/tuple.h
+++ b/include/util/tuple.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <functional>
+#include <tuple>
+
+
 /**
  *  This file is only necessary to deal with implementations missing some
  *  required functionality in the STL.


### PR DESCRIPTION
This adds some infrastructure to perform static analysis on the packet library.

The Clang static analyzer found one "bug": a dead store to `iter` in `source/eddsa_signature_encoder.cpp`. This is indeed a dead store, but for stylistic reasons I could understand keeping it. @omartijn opinions?

clang-tidy found the same dead store as the static analyzer, and also reports a warning about a virtual call in a constructor within Crypto++. That seems out of scope here, though.

---

By making a contribution to this project, I certify that:

        (a) The contribution was created in whole or in part by me and I
            have the right to submit it under the GPL-3.0 license; or

        (b) The contribution is based upon previous work that, to the best
            of my knowledge, is covered under an appropriate open source
            license and I have the right under that license to submit that
            work with modifications, whether created in whole or in part
            by me, under GPL-3.0 license; or

        (c) The contribution was provided directly to me by some other
            person who certified (a), (b) or (c) and I have not modified
            it.

        (d) I understand and agree that this project and the contribution
            are public and that a record of the contribution (including all
            personal information I submit with it, including my sign-off) is
            maintained indefinitely and may be redistributed consistent with
            this project or the license(s) involved.
