### PR TITLE
Add options for memory- and address sanitizer to CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8.0)
+cmake_minimum_required(VERSION 3.13.0)
 
 project(pgp-packet-library
     VERSION     0.1.1
@@ -109,6 +109,37 @@ elseif(CMAKE_COMPILER_IS_GNUCXX)
     target_compile_options(pgp-packet PRIVATE -Wall -Wextra -Wdeprecated -Wno-sign-compare)
 else()
     message(WARNING "Unsupported compiler: don't know what compiler flags to add for this compiler!")
+endif()
+
+# allow the user to enable some clang sanitizers
+option(ASAN "Enable the address sanitizer (clang only)" OFF)
+option(MSAN "Enable the memory sanitizer (clang only)" OFF)
+
+# function to enable a particular clang sanitizer
+function(enable_clang_sanitizer sanitizer)
+    # does the user want to use the address sanitizer
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+        # enable the address sanitizer during build- and link step
+        target_compile_options(pgp-packet PUBLIC -fsanitize=${sanitizer})
+        target_compile_options(pgp-packet PUBLIC -fno-omit-frame-pointer)
+        target_compile_options(pgp-packet PUBLIC -fno-optimize-sibling-calls)
+        target_link_options(pgp-packet PUBLIC -fsanitize=${sanitizer})
+    else()
+        # unable to enable the option for this compiler
+        message(WARNING "Unable to enable ${sanitizer} sanitizer, compiler ${CMAKE_CXX_COMPILER_ID} not supported")
+    endif()
+endfunction()
+
+# we cannot enable both sanitizers at the same time
+if (ASAN AND MSAN)
+    # notify the user this is impossible
+    message(FATAL_ERROR "Address Sanitizer and Memory Sanitizer cannot be used simultaneously")
+elseif(ASAN)
+    # enable address sanitizer
+    enable_clang_sanitizer(address)
+elseif(MSAN)
+    #enable memory sanitizer
+    enable_clang_sanitizer(memory)
 endif()
 
 add_subdirectory(tests)


### PR DESCRIPTION
CMakeLists.txt now supports the following options
  - MSAN, boolean, indicating whether to use the memory sanitizer
  - ASAN, boolean, indicating whether to use the address sanitizer

Note that it is not possible to enable both options simultaneously, and
that this is only supported when compiling with clang. Targets using
this library will inherit these options and will also be compiled with
the same sanitizers as enabled for the packet library.

By making a contribution to this project, I certify that:

        (a) The contribution was created in whole or in part by me and I
            have the right to submit it under the GPL-3.0 license; or

        (b) The contribution is based upon previous work that, to the best
            of my knowledge, is covered under an appropriate open source
            license and I have the right under that license to submit that
            work with modifications, whether created in whole or in part
            by me, under GPL-3.0 license; or

        (c) The contribution was provided directly to me by some other
            person who certified (a), (b) or (c) and I have not modified
            it.

        (d) I understand and agree that this project and the contribution
            are public and that a record of the contribution (including all
            personal information I submit with it, including my sign-off) is
            maintained indefinitely and may be redistributed consistent with
            this project or the license(s) involved.
