### PR TITLE
Exclude gtest from installed files

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,5 @@
-add_subdirectory(googletest)
+# use EXCLUDE_FROM_ALL to avoid gtest installation
+add_subdirectory(googletest EXCLUDE_FROM_ALL)
 
 set(test-sources "")
 foreach(source ${pgp-packet-sources})


### PR DESCRIPTION
When adding gtest using add_subdirectory it will add its headers and library to the install target. Since we only need it for running the tests, and don't want to install it, we now use EXCLUDE_FROM_ALL, so only targets explicitly depended on will be built.

By making a contribution to this project, I certify that:

        (a) The contribution was created in whole or in part by me and I
            have the right to submit it under the GPL-3.0 license; or

        (b) The contribution is based upon previous work that, to the best
            of my knowledge, is covered under an appropriate open source
            license and I have the right under that license to submit that
            work with modifications, whether created in whole or in part
            by me, under GPL-3.0 license; or

        (c) The contribution was provided directly to me by some other
            person who certified (a), (b) or (c) and I have not modified
            it.

        (d) I understand and agree that this project and the contribution
            are public and that a record of the contribution (including all
            personal information I submit with it, including my sign-off) is
            maintained indefinitely and may be redistributed consistent with
            this project or the license(s) involved.
