### PR TITLE
Cmake config improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -199,6 +199,11 @@ install(
         lib/cmake/pgp-packet
 )
 
+install(
+    DIRECTORY   cmake/Modules
+    DESTINATION lib/cmake/pgp-packet
+)
+
 find_package(PythonInterp)
 find_program(iwyu_tool_path NAMES iwyu_tool.py iwyu_tool)
 if (iwyu_tool_path AND PYTHONINTERP_FOUND)

--- a/README.md
+++ b/README.md
@@ -61,6 +61,22 @@ This command might need administrative privileges. Depending on your operating s
 
 The easiest way to use the library is by setting up a CMake project and use the provided CMake modules under `cmake/Modules` to locate the dependencies, a clear example of how to do it can be found in the [pgp-key-generation repository](https://github.com/summitto/pgp-key-generation/).
 
+The library provides a CMake configuration file which sets up all the needed dependencies, the following `CMakeLists.txt` should be enough to run the code examples
+```cmake
+cmake_minimum_required(VERSION 3.13.0)
+
+project(pgp-packet-example
+        VERSION 0.1.1
+        LANGUAGES CXX)
+
+find_package(pgp-packet-packet REQUIRED)
+
+add_executable(pgp-packet-example example.cpp)
+target_link_libraries(pgp-packet-example pgp-packet)
+```
+
+Otherwise the dependencies need to be installed and linked manually
+
 ### Creating a simple packet
 
 Since PGP packets can contain very different types of data, the body of the `pgp::packet` is an `std::variant`, which gives easy access to the packet-specific fields. If for some reason your standard library is outdated and does not provide `std::variant`, the library falls back to a bundled third-party variant implementation called `mpark::variant`. A type alias for the variant class and it's helper definitions is provided under the `pgp namespace` to make use of the right package.

--- a/cmake/pgp-packet-config.cmake
+++ b/cmake/pgp-packet-config.cmake
@@ -1,1 +1,16 @@
 include("${CMAKE_CURRENT_LIST_DIR}/pgp-packet-targets.cmake")
+
+# set module path
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_LIST_DIR}/Modules/)
+
+# find boost and sodium
+find_package(Boost              REQUIRED)
+find_package(sodium     1.0.16  REQUIRED)
+
+# first try to find CryptoPP built using CMake
+find_package(cryptopp CONFIG QUIET)
+
+# if this didn't work, use our built-in search tool
+if (NOT TARGET cryptopp-static)
+    find_package(CryptoPP REQUIRED)
+endif()


### PR DESCRIPTION
By making a contribution to this project, I certify that:

        (a) The contribution was created in whole or in part by me and I
            have the right to submit it under the GPL-3.0 license; or

        (b) The contribution is based upon previous work that, to the best
            of my knowledge, is covered under an appropriate open source
            license and I have the right under that license to submit that
            work with modifications, whether created in whole or in part
            by me, under GPL-3.0 license; or

        (c) The contribution was provided directly to me by some other
            person who certified (a), (b) or (c) and I have not modified
            it.

        (d) I understand and agree that this project and the contribution
            are public and that a record of the contribution (including all
            personal information I submit with it, including my sign-off) is
            maintained indefinitely and may be redistributed consistent with
            this project or the license(s) involved.


This change provides an easy way to use the library with a minimum cmake lists which looks like this:

```cmake
cmake_minimum_required(VERSION 3.13.0)
project(pgp-packet-example
        VERSION 0.1.1
        LANGUAGES CXX)
find_package(pgp-packet-packet REQUIRED)
add_executable(pgp-packet-example example.cpp)
target_link_libraries(pgp-packet-example pgp-packet)
```

I also documented a clarification stating that dependencies have to be linked manually if for some reason the user doesn't want to use the provided CMake config file for it