### PR TITLE
Fix build on newer Ubuntu, add CI tests with g++ 11, Clang 14

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,55 +1,24 @@
 name: macos-latest
 
-on:
+'on':
   push:
-    branches: [ master ]
+    branches:
+      - master
   pull_request:
-    branches: [ master ]
+    branches:
+      - master
 
 jobs:
-  appleclang-minimum:
-    name: appleclang-10.0.1
-    runs-on: macos-latest
-    env:
-      DEVELOPER_DIR: /Applications/Xcode_10.3.app/Contents/Developer
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: submodules
-      run: git submodule update --init --recursive
-    - name: dependencies
-      run: | 
-        brew install boost
-        curl -O https://www.cryptopp.com/cryptopp820.zip
-        unzip cryptopp820.zip -d cryptopp820
-        make -C cryptopp820 shared all
-        make -C cryptopp820 install
-    - name: cmake
-      run: cmake -B build -DCMAKE_BUILD_TYPE=Debug
-    - name: build
-      run: cmake --build build
-    - name: test
-      run: ./build/tests/tests
-    - name: examples
-      run: |
-        make install -C build
-        cd examples
-        cmake -B build
-        make -C build
-        ./build/create_simple_packet
-        ./build/encoding_and_decoding
-        ./build/key_from_raw_data
-
   appleclang-latest:
-    name: appleclang-11.0.3
-    runs-on: macos-latest
+    name: appleclang-13.0.0
+    runs-on: macos-11
 
     steps:
     - uses: actions/checkout@v2
     - name: submodules
       run: git submodule update --init --recursive
     - name: dependencies
-      run: | 
+      run: |
         brew install boost
         curl -O https://www.cryptopp.com/cryptopp820.zip
         unzip cryptopp820.zip -d cryptopp820

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -1,16 +1,18 @@
 name: ubuntu-latest
 
-on:
+'on':
   push:
-    branches: [ master ]
+    branches:
+      - master
   pull_request:
-    branches: [ master ]
+    branches:
+      - master
 
 jobs:
   clang-minimum:
     name: clang++-6
-    runs-on: ubuntu-latest
-    
+    runs-on: ubuntu-20.04
+
     steps:
     - uses: actions/checkout@v2
     - name: submodules
@@ -35,10 +37,10 @@ jobs:
         ./build/encoding_and_decoding
         ./build/key_from_raw_data
 
-  clang-latest:
+  clang-9:
     name: clang++-9
-    runs-on: ubuntu-latest
-    
+    runs-on: ubuntu-20.04
+
     steps:
     - uses: actions/checkout@v2
     - name: submodules
@@ -65,7 +67,7 @@ jobs:
 
   gcc-minimum:
     name: g++-8
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2
@@ -91,9 +93,9 @@ jobs:
         ./build/encoding_and_decoding
         ./build/key_from_raw_data
 
-  gcc-latest:
+  gcc-9:
     name: g++-9
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -21,6 +21,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y libsodium-dev libcrypto++-dev libboost-all-dev
+        sudo apt-get install -y clang-6.0 lldb-6.0 lld-6.0 clang-format-6.0
     - name: cmake
       run: cmake -B build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=clang++-6.0
     - name: build
@@ -49,6 +50,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y libsodium-dev libcrypto++-dev libboost-all-dev
+        sudo apt-get install -y clang-9 lldb-9 lld-9 clang-format-9
     - name: cmake
       run: cmake -B build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=clang++-9
     - name: build
@@ -77,6 +79,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y libsodium-dev libcrypto++-dev libboost-all-dev
+        sudo apt-get install -y g++-8
     - name: cmake
       run: cmake -B build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=g++-8
     - name: build

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -67,6 +67,34 @@ jobs:
         ./build/encoding_and_decoding
         ./build/key_from_raw_data
 
+  clang-14:
+    name: clang++-14
+    runs-on: ubuntu-22.04
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: submodules
+      run: git submodule update --init --recursive
+    - name: dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libsodium-dev libcrypto++-dev libboost-all-dev
+    - name: cmake
+      run: cmake -B build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=clang++-14
+    - name: build
+      run: cmake --build build -j$(nproc)
+    - name: test
+      run: ./build/tests/tests
+    - name: examples
+      run: |
+        sudo make install -C build
+        cd examples
+        cmake -B build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=clang++-14
+        make -C build
+        ./build/create_simple_packet
+        ./build/encoding_and_decoding
+        ./build/key_from_raw_data
+
   gcc-minimum:
     name: g++-8
     runs-on: ubuntu-20.04
@@ -119,6 +147,34 @@ jobs:
         sudo make install -C build
         cd examples
         cmake -B build -DCMAKE_CXX_COMPILER=g++-9
+        make -C build
+        ./build/create_simple_packet
+        ./build/encoding_and_decoding
+        ./build/key_from_raw_data
+
+  gcc-11:
+    name: g++-11
+    runs-on: ubuntu-22.04
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: submodules
+      run: git submodule update --init --recursive
+    - name: dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libsodium-dev libcrypto++-dev libboost-all-dev
+    - name: cmake
+      run: cmake -B build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=g++-11
+    - name: build
+      run: cmake --build build -j$(nproc)
+    - name: test
+      run: ./build/tests/tests
+    - name: examples
+      run: |
+        sudo make install -C build
+        cd examples
+        cmake -B build -DCMAKE_CXX_COMPILER=g++-11
         make -C build
         ./build/create_simple_packet
         ./build/encoding_and_decoding

--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ The library is centered around the pgp::packet class. This class can be construc
 ## Building the library
 
 The library has been tested to work with the following C++ compilers:
-| Compiler      | Version(s)      | Environment     |
-| :---          |     :---:       | :---            |
-| Apple clang   | 10.0.1/11.0.3   | macOS-10.15.4   |
-| clang++       | 6.0.0/9.0.0     | ubuntu-18.04    |
-| g++           | 8.4.0/9.3.0     | ubuntu-18.04    |
+| Compiler    | Version(s)               | Environment    |
+|:------------|:------------------------:|:---------------|
+| Apple clang | `13.0.0.13000029`        | `macOS-11.6.6` |
+| clang++     | `6.0.1`/`9.0.1`/`14.0.0` | `ubuntu-20.04` |
+| g++         | `8.4.0`/`9.4.0`/`11.2.0` | `ubuntu-20.04` |
 
 [The compiler crashes](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=91058) for versions of g++ lower than 8.0
 
@@ -97,9 +97,9 @@ which parses the binary data read by the decoder, and has an
 `encode` method, which produces the binary representation and
 passes it to an `encoder` instance.
 
-[Let's look at an example](examples/encoding_and_decoding.cpp), 
+[Let's look at an example](examples/encoding_and_decoding.cpp),
 once again using the user_id type (due to its simplicity).
-The packet is encoded to its binary representation, which is then 
+The packet is encoded to its binary representation, which is then
 read. We verify that this indeed results in the same
 packet as we started with.
 

--- a/cmake/Modules/FindCryptoPP.cmake
+++ b/cmake/Modules/FindCryptoPP.cmake
@@ -2,7 +2,8 @@ find_path(CryptoPP_INCLUDE_DIR NAMES cryptopp/config.h DOC "CryptoPP include dir
 find_library(CryptoPP_LIBRARY NAMES cryptopp DOC "CryptoPP library")
 
 if(CryptoPP_INCLUDE_DIR)
-    file(STRINGS ${CryptoPP_INCLUDE_DIR}/cryptopp/config.h _config_version REGEX "CRYPTOPP_VERSION")
+    find_file(CryptoPP_CONFIG_HEADER NAMES config_ver.h config.h PATHS ${CryptoPP_INCLUDE_DIR}/cryptopp)
+    file(STRINGS ${CryptoPP_CONFIG_HEADER} _config_version REGEX "CRYPTOPP_VERSION")
     string(REGEX MATCH "([0-9])([0-9])([0-9])" _match_version ${_config_version})
     set(CryptoPP_VERSION_STRING "${CMAKE_MATCH_1}.${CMAKE_MATCH_2}.${CMAKE_MATCH_3}")
 endif()

--- a/source/eddsa_signature_encoder.cpp
+++ b/source/eddsa_signature_encoder.cpp
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <algorithm>
 #include <array>
+#include <cassert>
 #include "util/span.h"
 
 


### PR DESCRIPTION
This PR fixes builds under Ubuntu 22.04 and adds CI tests for g++ 11 and Clang 14. It also updates the existing CI jobs so that they run after the upstream images have been changed to have earlier compiler versions removed. 

---

By making a contribution to this project, I certify that:

        (a) The contribution was created in whole or in part by me and I
            have the right to submit it under the GPL-3.0 license; or

        (b) The contribution is based upon previous work that, to the best
            of my knowledge, is covered under an appropriate open source
            license and I have the right under that license to submit that
            work with modifications, whether created in whole or in part
            by me, under GPL-3.0 license; or

        (c) The contribution was provided directly to me by some other
            person who certified (a), (b) or (c) and I have not modified
            it.

        (d) I understand and agree that this project and the contribution
            are public and that a record of the contribution (including all
            personal information I submit with it, including my sign-off) is
            maintained indefinitely and may be redistributed consistent with
            this project or the license(s) involved.
